### PR TITLE
Backend serverport-module.js file auto-generation in the frontend app folders

### DIFF
--- a/control/files.js
+++ b/control/files.js
@@ -75,11 +75,13 @@ files.getAppsInstalled = async () => { // Each app should correspond to a folder
         for (const fileInInfoFolder of filesInInfoFolder) {
           if (fileInInfoFolder.includes('app-icon')) { iconfound = fileInInfoFolder; }
         }
-        // Ensure .js file with the port and frontend icon will be there
+        // Ensure .js files with the port and frontend icon will be there
         backendStaticPath = path.join(routeToAppsFolder, validApp, 'app', 'backend-static');
         await fs.ensureDir(backendStaticPath);
         await fs.ensureFile(path.join(backendStaticPath, 'serverport.js'));
         await fs.writeFile(path.join(backendStaticPath, 'serverport.js'), `const serverPort = ${config.server.PORT};`);
+        await fs.ensureFile(path.join(backendStaticPath, 'serverport-module.js'));
+        await fs.writeFile(path.join(backendStaticPath, 'serverport-module.js'), `module.exports = ${config.server.PORT};`);
         if (iconfound) { 
           await fs.copyFile(path.join(infoFolder, iconfound), path.join(backendStaticPath, iconfound));
           routeToAppIcon = `/${validApp}/${backendStaticDir}/${iconfound}`;


### PR DESCRIPTION
(The backend already did that but the file had another format, this is a module.exports file doing the same).

With this the frontend apps can import the file and dinamically know which serverport the backend is listening to. The frontend developers can work 100% abstract without knowing which port will be used by the backend: the front app will import the file (generated by the backend when the server is up), read it and use the variable value.