### PR TITLE
Fixed: wrong broadcast frontend messages are just ignored

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -43,7 +43,7 @@ io.on('connection', (socket) => {
   });
   socket.on('msgToBroadcast', (message) => {
     const messageToBroadcast = control.msgToBroadcast(message);
-    if (messageToBroadcast.msgOk) { // Otherwise ignored
+    if (messageToBroadcast && messageToBroadcast.msgOk) { // Otherwise ignored
       const stringified = JSON.stringify(messageToBroadcast.msgOk);
       io.emit('broadcast', stringified);
     }


### PR DESCRIPTION
Before the fix a frontend broadcast message that wasn't properly formatted could cause a backend error message (visible for the sysadmin within the server). Now the well made broadcasts requests still work normally, and the bad ones simply have no consecuence at all.